### PR TITLE
Upload -- Modify metadata to be sent as individual fields in the form

### DIFF
--- a/src/pages/Project/Project.tsx
+++ b/src/pages/Project/Project.tsx
@@ -214,14 +214,9 @@ function Project() {
         }
       }
 
-      // Add JSON metadata as a Blob
-      const jsonBlob = new Blob([JSON.stringify({
-        projectId: id,
-        userId: user.username,
-        commitMessage: commitMessage,
-      })], { type: "application/json" });
-      
-      formData.append("jsonData", jsonBlob);
+      formData.append("projectId", id);
+      formData.append("userId", user.username);
+      formData.append("commitMessage", commitMessage);
 
       // Upload with progress tracking
       const response = await axios.post(`http://${window.location.hostname}:3333/api/upload`, formData, {


### PR DESCRIPTION
This is needed to work after the backend refactoring of the upload route.
Rather than sending metadata (userid, projectid, commit message) in a file, we send it as individual fields of the form. 